### PR TITLE
Update build runner to Windows 2025

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -6,7 +6,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     steps:
       - name: Checkout


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI build environment to use latest Windows 2025 GitHub-hosted runner, improving build reliability, compatibility with newer toolchains, and access to up-to-date security patches. No changes to application behavior or features. Release process remains the same; deployments unaffected. Developers may see minor differences in build logs and timings over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->